### PR TITLE
Change `graph_builder` task to `graph` task

### DIFF
--- a/frontend/src/components/TaskDetails.js
+++ b/frontend/src/components/TaskDetails.js
@@ -128,7 +128,7 @@ function TaskDetails({
    * Main click handler for the "Go to WorkGraph" button
    */
   const handleWorkFlowClick = () => {
-    if (nodeType === 'GRAPH_BUILDER') {
+    if (nodeType === 'GRAPH_TASK') {
       // Only valid if we have a processPk
       if (processPk) {
         navigate(`/workgraph/${processPk}`);
@@ -163,12 +163,12 @@ function TaskDetails({
 
   /**
    * isButtonDisabled logic:
-   *  - GRAPH_BUILDER => disabled if no processPk
+   *  - GRAPH_TASK => disabled if no processPk
    *  - WORKGRAPH => always enabled (sub-route is fallback)
    *  - MAP => enabled only if state in [RUNNING, FINISHED, FAILED], else disabled
    */
   let isButtonDisabled = false;
-  if (nodeType === 'GRAPH_BUILDER') {
+  if (nodeType === 'GRAPH_TASK') {
     isButtonDisabled = !processPk;
   }
   else if (nodeType === 'WORKGRAPH') {
@@ -210,8 +210,8 @@ function TaskDetails({
 
       <TaskDetailsTitle>Task Details</TaskDetailsTitle>
 
-      {/* Show button only if type is GRAPH_BUILDER, WORKGRAPH, or MAP */}
-      {['GRAPH_BUILDER', 'WORKGRAPH', 'MAP'].includes(nodeType) && (
+      {/* Show button only if type is GRAPH_TASK, WORKGRAPH, or MAP */}
+      {['GRAPH_TASK', 'WORKGRAPH', 'MAP'].includes(nodeType) && (
         <WorkFlowButton onClick={handleWorkFlowClick} disabled={isButtonDisabled}>
           Go to WorkGraph
         </WorkFlowButton>


### PR DESCRIPTION
In the latest `aida-workgraph` from the github repo, the `graph_builder` task is replaced by `graph` task. This PR updates the GUI for this change.



**Note:** In principle, this should move to the `aiida-gui-workgraph` plugin. The aiida-gui should only provide a plugin entry point mount this.